### PR TITLE
A compatibility patch for some of the visuMZ plugins and a proposed fix

### DIFF
--- a/plugins/Cyclone-Movement.js
+++ b/plugins/Cyclone-Movement.js
@@ -1348,6 +1348,21 @@ CycloneMovement.patchClass(Game_Map, $super => class {
   regionId(x, y) {
     return $super.regionId.call(this, Math.floor(x), Math.floor(y));
   }
+  terrainTag(x, y) {
+	if (this.isValid(x, y)) {
+        x = Math.round(x);
+        y = Math.round(y);
+        const flags = this.tilesetFlags();
+        const tiles = this.layeredTiles(x, y);
+        for (const tile of tiles) {
+            const tag = flags[tile] >> 12;
+            if (tag > 0) {
+                return tag;
+            }
+        }
+    }
+    return 0;
+  }
 });
 
 const addPixelMovementToClass = (classRef) => {

--- a/plugins/Cyclone-Movement.js
+++ b/plugins/Cyclone-Movement.js
@@ -1378,10 +1378,10 @@ const addPixelMovementToClass = (classRef) => {
     get lastX() {
       return this.lastXAt(this._x);
     }
-    get centerX() {
+    get middleX() {
       return Math.round(this.left + (this.getWidth() / 2));
     }
-    get centerY() {
+    get middleY() {
       return Math.round(this.top + (this.getHeight() / 2));
     }
 
@@ -2442,7 +2442,7 @@ const addPixelMovementToClass = (classRef) => {
     }
 
     terrainTag() {
-      return $gameMap.terrainTag(this.centerX, this.centerY);
+      return $gameMap.terrainTag(this.middleX, this.middleY);
     }
   });
 };


### PR DESCRIPTION
Latest patch which fixed terrainTag issue, was incompatible with some of the visuMZ plugins due to similar naming scheme. This simple patch aims to fix it without changing too much of a code.