### PR TITLE
Fix LayerPosition param not being recognized by RPGM

### DIFF
--- a/plugins/Cyclone-AdvancedMaps.js
+++ b/plugins/Cyclone-AdvancedMaps.js
@@ -390,7 +390,7 @@
  *
  * @param position
  * @text Position
- * @type Struct<LayerPosition>
+ * @type struct<LayerPosition>
  * @desc The top left position of this layer.
  * @default {}
  *


### PR DESCRIPTION
Not sure if a capitalized S ever worked, but I can at least say that in the latest version of RPGM MZ, it needs to be lowercased, otherwise the plugin settings won't recognize it as a valid structure