### PR TITLE
Fix tileset flags from previous map being left over

### DIFF
--- a/source/ExtraTilesets/src/Game_Map.js
+++ b/source/ExtraTilesets/src/Game_Map.js
@@ -9,6 +9,7 @@ CycloneExtraTilesets.patchClass(Game_Map, $super => class {
 
   buildTilesetFlags() {
     if (!this._extraTilesetId || this._extraTilesetId === this._tilesetId) {
+      this._allFlags = undefined;
       return;
     }
 


### PR DESCRIPTION
- Going from a map with extra tilesets to a map without would make the map without extra tilesets be completely broken, as it would get its flags from the leftover `_allFlags` property that was computed for the previous map
- Tested on RMMV 1.6.2 (This issue was observed on MV, I do not know if it occurs on MZ but I would assume so)